### PR TITLE
READMEのsupport IE versionを直す

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ shellから以下のコマンドを実行することで、各種ビルド・タ
 - Javascript: [ES2015(ECMAScript 6)](https://babeljs.io/docs/learn-es2015/)
 
 ## 対応ブラウザ
-- 各種モダンブラウザ最新バージョン・IE9以上
+- 各種モダンブラウザ最新バージョン・IE10以上
   - 対応ブラウザを変更する場合、`src/config/pleeease.json`の`autoprefixer.browsers`を修正することをお忘れなく
   - またIE8に対応する場合は、bowerのjQueryを1系にすることもお忘れなく
 


### PR DESCRIPTION
#17 の対応。
pleeeaseの設定では既に`ie >= 10`だったり、 #16 を入れようとしたりしてるので、IE10からサポートという方が実状に合っている。