### PR TITLE
babelのかわりにbabel-coreを使う

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Kayac Inc.",
   "license": "MIT",
   "devDependencies": {
-    "babel": "6.3.*",
+    "babel-core": "^6.13.2",
     "babel-preset-es2015": "6.3.*",
     "babelify": "7.2.*",
     "browser-sync": "2.11.*",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "author": "Kayac Inc.",
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^6.13.2",
     "babel-preset-es2015": "6.3.*",
     "babelify": "7.2.*",
     "browser-sync": "2.11.*",


### PR DESCRIPTION
> npm WARN deprecated babel@6.3.26: Babel's CLI commands have been moved from the babel package to the babel-cli package

らしい。[公式](https://github.com/babel/babel)も参考にして、babelではなくbabel-coreの方をつかう。
