### PR TITLE
browser-syncの設定・optionを調整

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -66,7 +66,8 @@ gulp.task('browser-sync', () => {
         server: {
             baseDir: HTDOCS
         },
-        startPath: BASE_PATH
+        startPath: BASE_PATH,
+        ghostMode: false
     });
 
     watch([`${SRC}/scss/**/*.scss`], gulp.series('sass', browserSync.reload));

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -17,7 +17,9 @@ import watch from 'gulp-watch';
 // const
 const SRC = './src';
 const CONFIG = './src/config';
-const DEST = './public';
+const HTDOCS = './public';
+const BASE_PATH = '/';
+const DEST = `${HTDOCS}${BASE_PATH}`;
 
 
 // css
@@ -62,8 +64,9 @@ gulp.task('html', gulp.series('pug'));
 gulp.task('browser-sync', () => {
     browserSync({
         server: {
-            baseDir: DEST
-        }
+            baseDir: HTDOCS
+        },
+        startPath: BASE_PATH
     });
 
     watch([`${SRC}/scss/**/*.scss`], gulp.series('sass', browserSync.reload));
@@ -80,3 +83,7 @@ gulp.task('serve', gulp.series('browser-sync'));
 // default
 gulp.task('build', gulp.parallel('css', 'js', 'html'));
 gulp.task('default', gulp.series('build', 'serve'));
+
+
+
+

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -84,7 +84,3 @@ gulp.task('serve', gulp.series('browser-sync'));
 // default
 gulp.task('build', gulp.parallel('css', 'js', 'html'));
 gulp.task('default', gulp.series('build', 'serve'));
-
-
-
-


### PR DESCRIPTION
* `DEST` の書き方を調整して、下層でサイトを作る場合に `BASE_PATH` だけ変えればよしなになるようにした。（browser-syncのstartPathとか）
* click, scroll, フォームのsubmit等々のsyncが、どちらかというとトラブルの元だったのでデフォルトでオフにした ( `ghostMode: false` )。
  * 参考→ https://www.browsersync.io/docs/options#option-ghostMode