### PR TITLE
スラッシュが二重になっているところがあった

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -23,8 +23,8 @@ const BASE_PATH = '/';
 const DEST = `${HTDOCS}${BASE_PATH}`;
 
 const revLogger = new RevLogger({
-    'style.css': `${DEST}/css/style.css`,
-    'script.js': `${DEST}/js/script.js`
+    'style.css': `${DEST}css/style.css`,
+    'script.js': `${DEST}js/script.js`
 });
 
 
@@ -35,7 +35,7 @@ gulp.task('sass', () => {
         .pipe(sassGlob())
         .pipe(sass())
         .pipe(pleeease(config))
-        .pipe(gulp.dest(`${DEST}/css`));
+        .pipe(gulp.dest(`${DEST}css`));
 });
 
 gulp.task('css', gulp.series('sass'));
@@ -46,7 +46,7 @@ gulp.task('browserify', () => {
         .transform(babelify)
         .bundle()
         .pipe(source('script.js'))
-        .pipe(gulp.dest(`${DEST}/js`));
+        .pipe(gulp.dest(`${DEST}js`));
 });
 
 gulp.task('js', gulp.parallel('browserify'));


### PR DESCRIPTION
DESTまわりがおかしなことになってたので直したいです
（デフォルトの `BASE_PATH` を `''` 、browserSyncのstartPath を `${BASE_PATH}/` にしてもいいかも）