### PR TITLE
extendsとincludeを絶対パスで参照できるように

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -59,7 +59,8 @@ gulp.task('pug', () => {
     return gulp.src(`${SRC}/pug/**/[!_]*.pug`)
         .pipe(pug({
             locals: locals,
-            pretty: true
+            pretty: true,
+            basedir: `${SRC}/pug`
         }))
         .pipe(gulp.dest(`${DEST}`));
 });

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -1,4 +1,4 @@
-extends layout/_DefaultLayout
+extends /layout/_DefaultLayout
 
 prepend ConfigBlock
   - page_name = ''


### PR DESCRIPTION
深い下層ページをつくるときやディレクトリ構造が変わりやすいときに真価を発揮します。