### PR TITLE
baseパスを組み込んで、css・jsを絶対パスに

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -55,6 +55,7 @@ gulp.task('js', gulp.parallel('browserify'));
 gulp.task('pug', () => {
     const locals = readConfig(`${CONFIG}/meta.yml`);
     locals.versions = revLogger.versions();
+    locals.basePath = BASE_PATH;
     
     return gulp.src(`${SRC}/pug/**/[!_]*.pug`)
         .pipe(pug({

--- a/src/pug/layout/_DefaultLayout.pug
+++ b/src/pug/layout/_DefaultLayout.pug
@@ -60,11 +60,11 @@ html(lang="ja")
 
     // stylesheet
     block StylesheetBlock
-      link(rel="stylesheet", href="css/style.css?v="+versions["style.css"])
+      link(rel="stylesheet", href=basePath + "/css/style.css?v="+versions["style.css"])
   body
     .wrapper
       block ContentBlock
 
     // javascript
     block JavascriptBlock
-      script(src="js/script.js?v="+versions["script.js"])
+      script(src=basePath + "/js/script.js?v="+versions["script.js"])


### PR DESCRIPTION
階層構造が多層になっている構成でも、js・cssの参照を同じ書き方できるように。