### PR TITLE
rev-loggerのバージョンを更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jquery": "2.*",
     "read-config": "2.0.*",
     "reset.css": "^2.0.2",
-    "rev-logger": "1.1.0",
+    "rev-logger": "1.1.1",
     "vinyl-source-stream": "1.1.*"
   },
   "babel": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4211,9 +4211,9 @@ resp-modifier@^5.0.0:
     debug "^2.2.0"
     minimatch "^2.0.1"
 
-rev-logger@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/rev-logger/-/rev-logger-1.1.0.tgz#7f3592519a6131c3ae32e1a4f7fac23f8cc6375f"
+rev-logger:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rev-logger/-/rev-logger-1.1.1.tgz#2f245039241201656a96667e6ca1d32232c0867e"
   dependencies:
     chokidar "^1.6.1"
     colors "0.6.*"


### PR DESCRIPTION
- node versionが古い場合
- `style.css` `script.js` が存在しない初期状態で実行するとエラーになる

という２点をfixした、 `1.1.1` に更新しました。