### PR TITLE
Pugのアンダースコアで始まるディレクトリを無視

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -57,7 +57,7 @@ gulp.task('pug', () => {
     locals.versions = revLogger.versions();
     locals.basePath = BASE_PATH;
     
-    return gulp.src([`${SRC}/pug/**/[!_]*.pug`, `!${SRC}/pug/_**/*`])
+    return gulp.src([`${SRC}/pug/**/[!_]*.pug`, `!${SRC}/pug/**/_*/**/*`])
         .pipe(pug({
             locals: locals,
             pretty: true,

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -57,7 +57,7 @@ gulp.task('pug', () => {
     locals.versions = revLogger.versions();
     locals.basePath = BASE_PATH;
     
-    return gulp.src(`${SRC}/pug/**/[!_]*.pug`)
+    return gulp.src([`${SRC}/pug/**/[!_]*.pug`, `!${SRC}/pug/_**/*`])
         .pipe(pug({
             locals: locals,
             pretty: true,


### PR DESCRIPTION
機能:
  以下のようなファイルを無視
    /_detail/index.pug
    /sub/_includes/index.pug
    /_partial/mixin/media-query.pug

便利どころ:
  HTML群を入れたりするときにディレクトリの中身をまるまる無視
  ページ量産用のPugファイルの置き場を作りやすい
